### PR TITLE
feat: Add support for customizable ads in v1.0.2

### DIFF
--- a/AutomaticAds.cs
+++ b/AutomaticAds.cs
@@ -1,213 +1,129 @@
 ﻿using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes;
-using CounterStrikeSharp.API.Core.Attributes.Registration;
-using CounterStrikeSharp.API.Modules.Admin;
-using CounterStrikeSharp.API.Modules.Utils;
-using System.Text.Json.Serialization;
 using CounterStrikeSharp.API.Modules.Timers;
-using static CounterStrikeSharp.API.Core.Listeners;
 
 namespace AutomaticAds;
 
-[MinimumApiVersion(247)]
-public class BaseConfigs : BasePluginConfig
-{
-    [JsonPropertyName("ChatPrefix")]
-    public string ChatPrefix { get; set; } = " [{GREEN}AutomaticAds]";
-
-    [JsonPropertyName("ChatMessage")]
-    public string ChatMessage { get; set; } = "{RED}AutomaticAds is the best plugin!";
-
-    [JsonPropertyName("AdminFlag")]
-    public string AdminFlag { get; set; } = "css_root";
-
-    [JsonPropertyName("ForceCommand")]
-    public string ForceCommand { get; set; } = "css_announce";
-
-    [JsonPropertyName("SendForceCommand")]
-    public string SendForceCommand { get; set; } = "{RED}You have successfully forced the ad to be sent.";
-
-    [JsonPropertyName("NoPermissions")]
-    public string NoPermissions { get; set; } = "{RED}You do not have permissions to use this command.";
-
-    [JsonPropertyName("ChatInterval")]
-    public float ChatInterval { get; set; } = 600;
-
-    [JsonPropertyName("PlaySoundName")]
-    public string? PlaySoundName { get; set; } = "ui/panorama/popup_reveal_01";
-}
-
+[MinimumApiVersion(296)]
 public class AutomaticAdsBase : BasePlugin, IPluginConfig<BaseConfigs>
 {
     public override string ModuleName => "AutomaticAds";
-    public override string ModuleVersion => "1.0.1";
-    public override string ModuleAuthor => "luca.uy and iancg";
+    public override string ModuleVersion => "1.0.2";
+    public override string ModuleAuthor => "luca.uy";
     public override string ModuleDescription => "I send automatic messages to the chat and play a sound alert for users to see the message.";
 
-    private bool _isDebugEnabled = false; // ACTIVAR O DESACTIVAR LOS MENSAJES DE DEBUG/LOGS
-    public CounterStrikeSharp.API.Modules.Timers.Timer? intervalMessages;
+    private readonly Dictionary<BaseConfigs.AdConfig, DateTime> lastAdTimes = new();
+    private readonly List<CounterStrikeSharp.API.Modules.Timers.Timer> timers = new();
+    private string _currentMap = "";
+
     public override void Load(bool hotReload)
     {
-        AddCommand(Config.ForceCommand, "Send the advertisement in a forced way", (player, commandInfo) =>
+        RegisterListener<Listeners.OnMapStart>(mapName =>
         {
-            if (player == null) return;
-
-            Log($"AdminFlag configurada: {Config.AdminFlag}");
-
-            var validador = new RequiresPermissions(@Config.AdminFlag);
-            validador.Command = Config.ForceCommand;
-
-            if (!validador.CanExecuteCommand(player))
-            {
-                string formattedNoPermissions = FormatMessage(Config.NoPermissions);
-                Log($"Mensaje de no permisos formateado: {formattedNoPermissions}");
-                player.PrintToChat($"{FormatMessage(Config.ChatPrefix)} {formattedNoPermissions}");
-                return;
-            }
-
-            Log("Comando para forzar el envío del mensaje recibido.");
-            SendMessageToAllPlayers($"{FormatMessage(Config.ChatPrefix)} {FormatMessage(Config.ChatMessage)}");
-            Log("Mensaje forzado enviado a todos los jugadores.");
-
-            string formattedSendForceCommand = FormatMessage(Config.SendForceCommand);
-            commandInfo.ReplyToCommand($"{FormatMessage(Config.ChatPrefix)} {formattedSendForceCommand}");
+            _currentMap = mapName;
         });
-        
+
+        if (hotReload)
+        {
+            _currentMap = Server.MapName;
+        }
+
         RegisterListener<Listeners.OnMapEnd>(() => Unload(true));
         RegisterListener<Listeners.OnMapStart>(OnMapStart);
     }
 
     public required BaseConfigs Config { get; set; }
 
-    private DateTime _lastMessageTime = DateTime.Now;
-
     public void OnConfigParsed(BaseConfigs config)
     {
-        Log("Configuración analizada.");
         ValidateConfig(config);
         Config = config;
-        Log("Configuración validada.");
+
+        foreach (var ad in Config.Ads)
+        {
+            lastAdTimes[ad] = DateTime.MinValue;
+        }
     }
 
     private void ValidateConfig(BaseConfigs config)
     {
-        Log("Validando configuración...");
-
-        if (config.ChatInterval > 3600)
+        foreach (var ad in config.Ads)
         {
-            config.ChatInterval = 3600;
-            Log("ChatInterval ajustado a 3600 segundos (máximo permitido).");
-        }
-
-        if (config.ChatInterval < 10)
-        {
-            config.ChatInterval = 10;
-            Log("ChatInterval ajustado a 10 segundos (mínimo permitido).");
+            if (ad.Interval > 3600)
+                ad.Interval = 3600;
+            if (ad.Interval < 10)
+                ad.Interval = 10;
         }
 
         if (config.ChatPrefix.Length > 80)
-        {
             config.ChatPrefix = "[AutomaticAds]";
-            Log("ChatPrefix ajustado a '[AutomaticAds]' (longitud máxima alcanzada).");
-        }
-
-        if (config.ChatMessage.Length > 400)
-        {
-            config.ChatMessage = "Your message is too large to send.";
-            Log("ChatMessage ajustado: 'Your message es demasiado largo para enviar.'");
-        }
 
         if (string.IsNullOrWhiteSpace(config.PlaySoundName))
-        {
             config.PlaySoundName = "";
-            Log("PlaySoundName ajustado a vacío (no se proporcionó sonido).");
-        }
     }
 
-    public void SendMessages()
-    {
-        intervalMessages = AddTimer(1.00f, () => {
-            Log("Inicio de ronda detectado.");
-            if (CanSendMessage())
-            {
-                SendMessageToAllPlayers($"{Config.ChatPrefix} {Config.ChatMessage}");
-                _lastMessageTime = DateTime.Now;
-                Log("Mensaje enviado a todos los jugadores.");
-            }
-            else
-            {
-                Log("No se puede enviar el mensaje en este momento.");
-            }
-        }, TimerFlags.REPEAT);
-    }
-
-    private bool CanSendMessage()
-    {
-        var secondsSinceLastMessage = (int)(DateTime.Now - _lastMessageTime).TotalSeconds;
-        Log($"Han pasado {secondsSinceLastMessage} segundos desde el último mensaje.");
-        return secondsSinceLastMessage >= Config.ChatInterval;
-    }
-
-    private void SendMessageToAllPlayers(string message)
-    {
-        Log("Enviando mensaje a todos los jugadores...");
-        var players = Utilities.GetPlayers();
-
-        if (players == null || players.Count == 0)
-        {
-            Log("No se encontraron jugadores.");
-            return;
-        }
-
-        MessageColorFormatter formatter = new MessageColorFormatter();
-
-        string formattedPrefix = formatter.FormatMessage(Config.ChatPrefix);
-        string formattedMessage = formatter.FormatMessage(Config.ChatMessage);
-
-        string finalMessage = $"{formattedPrefix} {formattedMessage}";
-
-        Log($"Mensaje final a enviar: {finalMessage}");
-
-        foreach (var player in players.Where(player => player != null && player.IsValid && player.Connected == PlayerConnectedState.PlayerConnected && !player.IsHLTV))
-        {
-            string playerName = player.PlayerName;
-
-            player.PrintToChat(finalMessage);
-            Log($"Mensaje enviado a {playerName}: {finalMessage}");
-
-            if (!string.IsNullOrWhiteSpace(Config.PlaySoundName))
-            {
-                player.ExecuteClientCommand($"play {Config.PlaySoundName}");
-                Log($"Sonido reproducido para {playerName}: {Config.PlaySoundName}");
-            }
-        }
-    }
-
-    private string FormatMessage(string message)
-    {
-        MessageColorFormatter formatter = new MessageColorFormatter();
-        return formatter.FormatMessage(message);
-    }
-
-    private void Log(string message)
-    {
-        if (_isDebugEnabled)
-        {
-            Console.WriteLine($"[DEBUG] {message}");
-        }
-    }
-
-    public void SetDebugEnabled(bool isEnabled)
-    {
-        _isDebugEnabled = isEnabled;
-    }
     private void OnMapStart(string mapName)
     {
         SendMessages();
     }
+
+    public void SendMessages()
+    {
+        foreach (var ad in Config.Ads)
+        {
+            var timer = AddTimer(1.00f, () =>
+            {
+                if (CanSendAd(ad))
+                {
+                    SendAdToPlayers(ad);
+                    lastAdTimes[ad] = DateTime.Now;
+                }
+            }, TimerFlags.REPEAT);
+
+            timers.Add(timer);
+        }
+    }
+
+    private bool CanSendAd(BaseConfigs.AdConfig ad)
+    {
+        string currentMap = _currentMap;
+        if (ad.Map != "all" && ad.Map != currentMap)
+        {
+            return false;
+        }
+
+        var secondsSinceLastMessage = (int)(DateTime.Now - lastAdTimes[ad]).TotalSeconds;
+        return secondsSinceLastMessage >= ad.Interval;
+    }
+
+    private void SendAdToPlayers(BaseConfigs.AdConfig ad)
+    {
+        var players = Utilities.GetPlayers();
+
+        if (players == null || players.Count == 0)
+            return;
+
+        MessageColorFormatter formatter = new MessageColorFormatter();
+        string formattedMessage = formatter.FormatMessage(ad.Message);
+
+        foreach (var player in players.Where(p => p != null && p.IsValid && p.Connected == PlayerConnectedState.PlayerConnected && !p.IsHLTV))
+        {
+            player.PrintToChat($"{Config.ChatPrefix} {formattedMessage}");
+
+            if (!ad.DisableSound && !string.IsNullOrWhiteSpace(Config.PlaySoundName))
+            {
+                player.ExecuteClientCommand($"play {Config.PlaySoundName}");
+            }
+        }
+    }
+
     public override void Unload(bool hotReload)
     {
-        intervalMessages?.Kill();
+        foreach (var timer in timers)
+        {
+            timer.Kill();
+        }
+        timers.Clear();
     }
 }

--- a/Config.cs
+++ b/Config.cs
@@ -6,14 +6,47 @@ namespace AutomaticAds;
 public class BaseConfigs : BasePluginConfig
 {
     [JsonPropertyName("ChatPrefix")]
-    public string ChatPrefix { get; set; } = " [{GREEN}AutomaticAds]";
+    public string ChatPrefix { get; set; } = " [{GREEN}AutomaticAds{WHITE}]{WHITE}";
 
     [JsonPropertyName("PlaySoundName")]
     public string? PlaySoundName { get; set; } = "ui/panorama/popup_reveal_01";
 
-
     [JsonPropertyName("Ads")]
-    public List<AdConfig> Ads { get; set; } = new();
+    public List<AdConfig> Ads { get; set; } = new()
+    {
+        new AdConfig
+        {
+            Message = "{RED}AutomaticAds is the best plugin!",
+            Map = "all",
+            Interval = 600,
+            DisableSound = false,
+            Flag = "all"
+        },
+        new AdConfig
+        {
+            Message = "{BLUE}Welcome to the server! {RED}Make sure to read the rules.",
+            Map = "all",
+            Interval = 800,
+            DisableSound = false,
+            Flag = "all"
+        },
+        new AdConfig
+        {
+            Message = "{BLUE}Thank you for supporting the server! {GOLD}Your contribution is greatly appreciated.",
+            Map = "all",
+            Interval = 1000,
+            DisableSound = true,
+            Flag = "@css/vip"
+        },
+        new AdConfig
+        {
+            Message = "{GOLD}Congratulations, you are playing on Mirage.",
+            Map = "de_mirage",
+            Interval = 1400,
+            DisableSound = true,
+            Flag = "all"
+        }
+    };
 
     public class AdConfig
     {

--- a/Config.cs
+++ b/Config.cs
@@ -1,0 +1,35 @@
+using CounterStrikeSharp.API.Core;
+using System.Text.Json.Serialization;
+
+namespace AutomaticAds;
+
+public class BaseConfigs : BasePluginConfig
+{
+    [JsonPropertyName("ChatPrefix")]
+    public string ChatPrefix { get; set; } = " [{GREEN}AutomaticAds]";
+
+    [JsonPropertyName("PlaySoundName")]
+    public string? PlaySoundName { get; set; } = "ui/panorama/popup_reveal_01";
+
+
+    [JsonPropertyName("Ads")]
+    public List<AdConfig> Ads { get; set; } = new();
+
+    public class AdConfig
+    {
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
+
+        [JsonPropertyName("flag")]
+        public string? Flag { get; set; } = null;
+
+        [JsonPropertyName("map")]
+        public string Map { get; set; } = "all";
+
+        [JsonPropertyName("interval")]
+        public float Interval { get; set; } = 600;
+
+        [JsonPropertyName("disableSound")]
+        public bool DisableSound { get; set; } = false;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Each item in the `Ads` list represents a single advertisement. Here are the fiel
 | Parameter       | Description                                                                                         | Required |
 |-----------------|-----------------------------------------------------------------------------------------------------|----------|
 | `message`       | The message/announcement to send in the chat. Supports colors.                                      | **YES**  |
-| `flag`          | Admin flag required to receive this message. Set to `null` to make it available to all players.     | **NO**   |
-| `map`           | The map where this ad should appear. Use `"all"` for all maps or specify a map name.                | **NO**   |
+| `flag`          | Admin flag required to receive this message. Set to `all` to make it available to all players.     | **YES**   |
+| `map`           | The map where this ad should appear. Use `"all"` for all maps or specify a map name.                | **YES**   |
 | `interval`      | The interval (in seconds) between sending this ad. Must be between `10` and `3600`.                 | **YES**  |
-| `disableSound`  | If `true`, no sound will be played when this ad is sent.                                            | **NO**   |
+| `disableSound`  | If `true`, no sound will be played when this ad is sent.                                            | **YES**   |
 
 ---
 
@@ -46,32 +46,39 @@ Here is an example configuration file:
 
 ```json
 {
-  "ChatPrefix": " [{GREEN}AutomaticAds]",
-  "AdminFlag": "css_root",
+  "ChatPrefix": " [{GREEN}AutomaticAds{WHITE}]{WHITE}",
   "PlaySoundName": "ui/panorama/popup_reveal_01",
   "Ads": [
     {
-      "message": "{RED}Welcome to our server! Have fun!",
-      "flag": null,
+      "message": "{RED}AutomaticAds is the best plugin!",
+      "flag": "all",
       "map": "all",
       "interval": 600,
       "disableSound": false
     },
     {
-      "message": "{GOLD}Thank you for supporting the server by purchasing VIP!",
-      "flag": "@css/vip",
+      "message": "{BLUE}Welcome to the server! {RED}Make sure to read the rules.",
+      "flag": "all",
       "map": "all",
       "interval": 800,
       "disableSound": false
     },
     {
-      "message": "{BLUE}Don't forget to join our Discord server!",
-      "flag": null,
+      "message": "{BLUE}Thank you for supporting the server! {GOLD}Your contribution is greatly appreciated.",
+      "flag": "@css/vip",
+      "map": "all",
+      "interval": 1000,
+      "disableSound": true
+    },
+    {
+      "message": "{GOLD}Congratulations, you are playing on Mirage.",
+      "flag": "all",
       "map": "de_mirage",
-      "interval": 1200,
+      "interval": 1400,
       "disableSound": true
     }
-  ]
+  ],
+  "ConfigVersion": 1
 }
 ```
 
@@ -83,7 +90,7 @@ Here is an example configuration file:
 ## TO-DO
 | Task                               | Status     | Description                                                                                     |
 |------------------------------------|------------|-------------------------------------------------------------------------------------------------|
-| Multiple ads with different intervals | **Done**    | Configure multiple advertisements with varying intervals.                                       |
+| Multiple ads with different intervals | **Complete**    | Configure multiple advertisements with varying intervals.                                       |
 | Option to target specific flags    | Pending    | Add an option to send messages only to users with specific admin flags.                         |
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,62 +1,89 @@
 # AutomaticAds CS2
-This plugin allows you to schedule and display announcements in the chat at customizable intervals. Each announcement is accompanied by a brief sound effect to capture players' attention seamlessly."
 
-https://github.com/user-attachments/assets/aae16cc4-7c67-477a-8c89-437d5c035211
+This plugin allows you to schedule and display announcements in the chat at customizable intervals. Each announcement is accompanied by a brief sound effect to capture players' attention seamlessly.
+
+---
 
 ## Installation
-1. Install [CounterStrike Sharp](https://github.com/roflmuffin/CounterStrikeSharp) and [Metamod:Source](https://www.sourcemm.net/downloads.php/?branch=master)
+1. Install [CounterStrike Sharp](https://github.com/roflmuffin/CounterStrikeSharp) and [Metamod:Source](https://www.sourcemm.net/downloads.php/?branch=master).
 
 2. Download [AutomaticAds.zip](https://github.com/wiruwiru/AutomaticAds-CS2/releases) from the releases section.
 
-3. Unzip the archive and upload it to the game server
+3. Unzip the archive and upload it to the game server.
 
 4. Start the server and wait for the configuration file to be generated.
 
-5. Complete the configuration file with the parameters of your choice.
+5. Edit the configuration file with the parameters of your choice.
 
 ---
 
-# Commands
-`!announce` `css_announce`  - You can use it to force the ad to be sent (Recommended for administrators).
+## Config
+The configuration file will be automatically generated when the plugin is first loaded. Below are the parameters you can customize:
+
+| Parameter        | Description                                                                                       | Required |
+|------------------|---------------------------------------------------------------------------------------------------|----------|
+| `ChatPrefix`     | Prefix displayed in the chat before each announcement. Supports colors.                          | **YES**  |
+| `PlaySoundName`  | Sound played when an announcement is sent. Leave it blank to disable.                             | **NO**   |
+| `Ads`            | List of advertisements to be sent. Each ad can be configured individually (see example below).    | **YES**  |
 
 ---
 
-# Config
-| Parameter | Description | Required     |
-| :------- | :------- | :------- |
-| `ChatPrefix` | This is the prefix that will appear in the chat when an advertisement is sent. |**YES** |
-| `ChatMessage` | This is the message/announcement that will be sent automatically by the plugin. |**YES** |
-| `AdminFlag` | Flag to allow access to “css_announce”.  |**YES** |
-| `ForceCommand` | You can choose the command you will use to force the sending of an announcement, for example “css_announce” or “css_anuncio”. |**YES** |
-| `SendForceCommand` | This is the message that will confirm that you have forced the ad to be sent. |**YES** |
-| `NoPermissions` | Message that will appear when someone without permissions tries to use the force command. |**YES** |
-| `ChatInterval` | Interval for the announcement to be sent (in seconds). |**YES** |
-| `PlaySoundName` | Sound that is played when sending the ad (if you don't know what you are doing leave it default), you can deactivate this function leaving the configuration empty ( example: “PlaySoundName”: “” ) |**YES** |
+### Ads Configuration
+Each item in the `Ads` list represents a single advertisement. Here are the fields available:
+
+| Parameter       | Description                                                                                         | Required |
+|-----------------|-----------------------------------------------------------------------------------------------------|----------|
+| `message`       | The message/announcement to send in the chat. Supports colors.                                      | **YES**  |
+| `flag`          | Admin flag required to receive this message. Set to `null` to make it available to all players.     | **NO**   |
+| `map`           | The map where this ad should appear. Use `"all"` for all maps or specify a map name.                | **NO**   |
+| `interval`      | The interval (in seconds) between sending this ad. Must be between `10` and `3600`.                 | **YES**  |
+| `disableSound`  | If `true`, no sound will be played when this ad is sent.                                            | **NO**   |
 
 ---
 
-## Configuration example
-```
+## Configuration Example
+Here is an example configuration file:
+
+```json
 {
   "ChatPrefix": " [{GREEN}AutomaticAds]",
-  "ChatMessage": "{RED}AutomaticAds is the best plugin!",
   "AdminFlag": "css_root",
-  "ForceCommand": "css_announce",
-  "SendForceCommand": "{RED}You have successfully forced the ad to be sent."
-  "NoPermissions": "{RED}You do not have permissions to use this command."
-  "ChatInterval": 600,
   "PlaySoundName": "ui/panorama/popup_reveal_01",
-  "ConfigVersion": 1
+  "Ads": [
+    {
+      "message": "{RED}Welcome to our server! Have fun!",
+      "flag": null,
+      "map": "all",
+      "interval": 600,
+      "disableSound": false
+    },
+    {
+      "message": "{GOLD}Thank you for supporting the server by purchasing VIP!",
+      "flag": "@css/vip",
+      "map": "all",
+      "interval": 800,
+      "disableSound": false
+    },
+    {
+      "message": "{BLUE}Don't forget to join our Discord server!",
+      "flag": null,
+      "map": "de_mirage",
+      "interval": 1200,
+      "disableSound": true
+    }
+  ]
 }
 ```
-List of available colors:
-`GREEN` `RED` `YELLOW` `BLUE` `ORANGE` `WHITE` `PURPLE` `GREY` `LIGHT_RED` `LIGHT_BLUE` `LIGHT_YELLOW` `LIGHT_PURPLE` `DARK_RED` 
-`BLUE_GREY` `DARK_BLUE` `LIME` `OLIVE` `GOLD` `SILVER` `MAGENTA`
+
+### List of Available Colors:
+`GREEN`, `RED`, `YELLOW`, `BLUE`, `ORANGE`, `WHITE`, `PURPLE`, `GREY`, `LIGHT_RED`, `LIGHT_BLUE`, `LIGHT_YELLOW`, `LIGHT_PURPLE`, `DARK_RED`, `BLUE_GREY`, `DARK_BLUE`, `LIME`, `OLIVE`, `GOLD`, `SILVER`, `MAGENTA`.
 
 ---
 
 ## TO-DO
-| Task                          | Status     | Description                                                                                              |
-|-------------------------------|------------|----------------------------------------------------------------------------------------------------------|
-| Multiple ads with different intervals | Pending    | Add functionality to configure multiple advertisements with varying time intervals.                      |
-| Option to send a message only to users with a certain flag | Pending    | Implement an option to specifically target messages to users with specific flags.                            |
+| Task                               | Status     | Description                                                                                     |
+|------------------------------------|------------|-------------------------------------------------------------------------------------------------|
+| Multiple ads with different intervals | **Done**    | Configure multiple advertisements with varying intervals.                                       |
+| Option to target specific flags    | Pending    | Add an option to send messages only to users with specific admin flags.                         |
+
+---


### PR DESCRIPTION
- Introduced the possibility to configure multiple ads with individual settings.
- Added the ability to set custom intervals for each ad.
- Implemented permission flags to restrict ads visibility to users with specific permissions.
- Added map-specific ads, allowing ads to be shown only on the set map.
- Included an option to disable notification sounds for specific ads.