### PR TITLE
feat: release v1.2.1 with new config options

### DIFF
--- a/AutomaticAds.cs
+++ b/AutomaticAds.cs
@@ -14,7 +14,7 @@ namespace AutomaticAds;
 public class AutomaticAdsBase : BasePlugin, IPluginConfig<BaseConfigs>
 {
     public override string ModuleName => "AutomaticAds";
-    public override string ModuleVersion => "1.2.0";
+    public override string ModuleVersion => "1.2.1";
     public override string ModuleAuthor => "luca.uy";
     public override string ModuleDescription => "Send automatic messages to the chat and play a sound alert for users to see the message.";
 

--- a/AutomaticAds.cs
+++ b/AutomaticAds.cs
@@ -32,8 +32,6 @@ public class AutomaticAdsBase : BasePlugin, IPluginConfig<BaseConfigs>
     private CCSGameRules? _gameRulesProxy;
 
     // CenterHtml message tracking and configuration
-    private const float CENTERHTML_DURATION_SECONDS = 5.0f;
-
     private readonly Dictionary<int, DateTime> _centerHtmlStartTimes = new();
     private readonly Dictionary<int, string> _activeCenterHtmlMessages = new();
     private readonly Dictionary<int, DateTime> _lastCenterHtmlUpdateTimes = new();
@@ -198,7 +196,7 @@ public class AutomaticAdsBase : BasePlugin, IPluginConfig<BaseConfigs>
                 var startTime = _centerHtmlStartTimes[playerId];
                 var elapsedTime = (currentTime - startTime).TotalSeconds;
 
-                if (elapsedTime >= CENTERHTML_DURATION_SECONDS)
+                if (elapsedTime >= Config.centerHtmlDisplayTime)
                 {
                     playersToRemove.Add(playerId);
                     continue;

--- a/Config/BaseConfigs.cs
+++ b/Config/BaseConfigs.cs
@@ -28,7 +28,7 @@ public class BaseConfigs : BasePluginConfig
     {
         new WelcomeConfig
         {
-            WelcomeMessage = "{BLUE}Welcome to the server {playername}! {RED}Playing on {map} with {players}/{maxplayers} players.",
+            WelcomeMessage = "{prefix} {BLUE}Welcome to the server {playername}! {RED}Playing on {map} with {players}/{maxplayers} players.",
             ViewFlag = "all",
             ExcludeFlag = "",
             DisableSound = false

--- a/Config/BaseConfigs.cs
+++ b/Config/BaseConfigs.cs
@@ -21,7 +21,10 @@ public class BaseConfigs : BasePluginConfig
     public bool EnableJoinLeaveMessages { get; set; } = true;
 
     [JsonPropertyName("WelcomeDelay")]
-    public float WelcomeDelay { get; set; } = 5.0f;
+    public float WelcomeDelay { get; set; } = 3.0f;
+
+    [JsonPropertyName("centerHtmlDisplayTime")]
+    public float centerHtmlDisplayTime { get; set; } = 5.0f;
 
     [JsonPropertyName("Welcome")]
     public List<WelcomeConfig> Welcome { get; set; } = new()

--- a/Config/ConfigValidator.cs
+++ b/Config/ConfigValidator.cs
@@ -9,6 +9,7 @@ public static class ConfigValidator
         ValidateAds(config.Ads);
         ValidateChatPrefix(config);
         ValidateGlobalPlaySound(config);
+        ValidateCenterHtmlDisplayTime(config);
     }
 
     private static void ValidateAds(List<BaseConfigs.AdConfig> ads)
@@ -56,4 +57,13 @@ public static class ConfigValidator
             config.GlobalPlaySound = string.Empty;
         }
     }
+
+    private static void ValidateCenterHtmlDisplayTime(BaseConfigs config)
+    {
+        if (config.centerHtmlDisplayTime <= 0)
+        {
+            config.centerHtmlDisplayTime = 5.0f;
+        }
+    }
+
 }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The configuration file will be automatically generated when the plugin is first 
 | `UseWelcomeMessage`  | Set to `true` to enable the welcome message. Set to `false` to disable it.                        | **YES**   |
 | `JoinLeaveMessages`  | Set `true` to enable custom connection and disconnection messages. Set `false` to disable it.                        | **YES**   |
 | `WelcomeDelay`  | This is the time the plugin will wait to send the welcome message after the player connects (**Default**: 3s).                        | **YES**   |
+| `centerHtmlDisplayTime`  | "Duration (in seconds) that ads with `displayType` set to `CenterHtml` will remain visible. (**Default**: 5s) | **YES**   |
 | `Welcome`     | Configuration for the welcome announcement. Supports variables ***(see example below)***. | **NO**   |
 | `JoinLeave`     | Configuration for connection and disconnection messages. Supports variables ***(see example below)***. | **NO**   |
 | `Ads`                | List of advertisements to be sent. Each ad can be configured individually ***(see example below)***. | **YES**  |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Here is an example configuration file:
   "UseWelcomeMessage": true,
   "Welcome": [
     {
-      "WelcomeMessage": "{BLUE}Welcome to the server {playername}! {RED}Playing on {map} with {players}/{maxplayers} players.",
+      "WelcomeMessage": "{prefix} {BLUE}Welcome to the server {playername}! {RED}Playing on {map} with {players}/{maxplayers} players.",
       "viewFlag": "all",
       "excludeFlag": "",
       "disableSound": false
@@ -128,6 +128,7 @@ You can use the following placeholders in your announcements:
 |--------------|---------------------------------------------------------------|
 | `{prefix}`       | A dynamic variable replaced with the value of ChatPrefix in each message. Enables optional inclusion or exclusion of the prefix.                                      |
 | `{ip}`       | The server's IP address.                                      |
+| `{port}`     | The server's port.                                            |
 | `{hostname}` | The server's hostname.                                        |
 | `{map}`      | The current map being played.                                 |
 | `{time}`     | The current time in the server's timezone.                    |

--- a/Services/WelcomeService.cs
+++ b/Services/WelcomeService.cs
@@ -77,9 +77,9 @@ public class WelcomeService
     private void SendWelcomeToPlayer(CCSPlayerController player, BaseConfigs.WelcomeConfig welcome, string playerName)
     {
         string prefix = _messageFormatter.FormatMessage(_config.ChatPrefix);
-        string welcomeMessage = _messageFormatter.FormatMessage(welcome.WelcomeMessage, playerName);
+        string welcomeMessage = _messageFormatter.FormatMessage(welcome.WelcomeMessage, playerName, prefix);
 
-        _playerManager.SendMessageToPlayer(player, $"{prefix} {welcomeMessage}");
+        _playerManager.SendMessageToPlayer(player, welcomeMessage);
 
         if (!welcome.DisableSound && !string.IsNullOrWhiteSpace(_config.GlobalPlaySound))
         {

--- a/Utils/MessageFormatter.cs
+++ b/Utils/MessageFormatter.cs
@@ -122,6 +122,7 @@ public class MessageFormatter
         try
         {
             string ip = GetServerIp();
+            string port = GetServerPort();
             string hostname = GetServerHostname();
             string map = Server.MapName;
             string time = DateTime.Now.ToString("HH:mm");
@@ -132,6 +133,7 @@ public class MessageFormatter
             return new Dictionary<string, string>
             {
                 { "{ip}", ip },
+                { "{port}", port },
                 { "{hostname}", hostname },
                 { "{map}", map },
                 { "{time}", time },
@@ -160,6 +162,20 @@ public class MessageFormatter
         catch
         {
             return "Unknown:27015";
+        }
+    }
+
+    private string GetServerPort()
+    {
+        try
+        {
+            var portCvar = ConVar.Find("hostport");
+            int port = portCvar?.GetPrimitiveValue<int>() ?? 27015;
+            return port.ToString();
+        }
+        catch
+        {
+            return "27015";
         }
     }
 
@@ -192,6 +208,7 @@ public class MessageFormatter
         return new Dictionary<string, string>
         {
             { "{ip}", "Unknown:27015" },
+            { "{port}", "27015" },
             { "{hostname}", Constants.ErrorMessages.Unknown },
             { "{map}", Server.MapName ?? "Unknown" },
             { "{time}", DateTime.Now.ToString("HH:mm") },


### PR DESCRIPTION
- Added `{port}` and `{prefix}` variables
- Removed default "Welcome" prefix for full message control
- Added `centerHtmlDisplayTime` config (CenterHtml ad duration)